### PR TITLE
Replace colorize with rainbow to make licensing consistent.

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ['~> 2.0']
 
   spec.add_dependency "mime-types"
-  spec.add_dependency "colorize"
+  spec.add_dependency "rainbow"
   spec.add_dependency "open_uri_redirections"
   spec.add_dependency "activesupport"
   spec.add_dependency "addressable"

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -1,5 +1,5 @@
 require 'csvlint'
-require 'rainbow/refinement'
+require 'rainbow'
 require 'json'
 require 'pp'
 require 'thor'
@@ -8,7 +8,6 @@ require 'active_support/inflector'
 
 module Csvlint
   class Cli < Thor
-    using Rainbow
 
     desc "myfile.csv OR csvlint http://example.com/myfile.csv", "Supports validating CSV files to check their syntax and contents"
 
@@ -109,7 +108,7 @@ module Csvlint
         output_string += ". #{location}" unless location.empty?
         output_string += ". #{error.content}" if error.content
 
-        puts output_string.color(color)
+        puts Rainbow(output_string).color(color)
 
         if dump
           pp error
@@ -123,7 +122,7 @@ module Csvlint
       end
 
       def return_error(message)
-        puts message.red
+        puts Rainbow(message).red
         exit 1
       end
 
@@ -155,7 +154,7 @@ module Csvlint
           }.to_json
           print json
         else
-          puts "\r\n#{csv} is #{validator.valid? ? "VALID".green : "INVALID".red}"
+          puts "\r\n#{csv} is #{validator.valid? ? Rainbow("VALID").green : Rainbow("INVALID").red}"
           print_errors(validator.errors,   dump)
           print_errors(validator.warnings, dump)
         end
@@ -185,9 +184,9 @@ module Csvlint
         lambda do |row|
           new_errors = row.errors.count
           if new_errors > @error_count
-            print "!".red
+            print Rainbow("!").red
           else
-            print ".".green
+            print Rainbow(".").green
           end
           @error_count = new_errors
         end


### PR DESCRIPTION
This PR fixes #214

Changes proposed in this pull request:

- Remove 'colorize' and  use 'rainbow' as production dependencies
- Only enable 'rainbow' if `$stdout.tty?` to keep behavior the same as it was previously

The first commit uses `rainbow/refinements` to make the code as similar to the `colorize` version as possible, but that breaks Ruby-2.0.0 compatibility. Now uses Rainbow's "presenter" style to support all the versions currently configured in Travis.

Using Rainbow introduces a risk for future maintainers: Rainbow colorizes based on a [global setting](https://github.com/sickill/rainbow#configuration).  So if some additional output stream (e.g., a separate warnings output file) were added, *and* the color refinements were called on it, they would be enabled/disabled based on the same flag as the cli uses.
  