### PR TITLE
Don't patch CSV#init_converters for ruby 2.5 compatibility

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -38,13 +38,15 @@ module Csvlint
         ESCAPE_RE[@re_chars][@re_esc][str]
       end
 
-      # Optimization: Disable the CSV library's converters feature.
-      # @see https://github.com/ruby/ruby/blob/v2_2_3/lib/csv.rb#L2100
-      def init_converters(options, field_name = :converters)
-        @converters = []
-        @header_converters = []
-        options.delete(:unconverted_fields)
-        options.delete(field_name)
+      if RUBY_VERSION < '2.5'
+        # Optimization: Disable the CSV library's converters feature.
+        # @see https://github.com/ruby/ruby/blob/v2_2_3/lib/csv.rb#L2100
+        def init_converters(options, field_name = :converters)
+          @converters = []
+          @header_converters = []
+          options.delete(:unconverted_fields)
+          options.delete(field_name)
+        end
       end
     end
 


### PR DESCRIPTION
## Background

- `csvlint` library patched the method `CSV#init_converters`
  - https://github.com/theodi/csvlint.rb/blob/master/lib/csvlint/validate.rb#L43-L49
- It's not compatible with ruby `2.5.0`
  - In earlier versions of ruby, it only accepts two arguments:
    - https://docs.ruby-lang.org/en/2.4.0/CSV.html#method-i-init_converters
  - However, in ruby `2.5.0`, the required arguments are increased to three
    - https://docs.ruby-lang.org/en/2.5.0/CSV.html#method-i-init_converters
- By removing this patch, `LineCSV` will fallback and use the default `#init_converters` method of `CSV` for ruby `2.5.0` and above.
- Currently, when using `csvlint` on `ruby 2.5.0`, all validations are raising exceptions with `:invalid_encoding` message. When it's not really the cause of the issue.
  - https://github.com/theodi/csvlint.rb/blob/7e1d38934535167f3ebe12c13128650cf82d78ee/lib/csvlint/validate.rb#L169

Please review and let me know your thoughts!

cc @jpmckinney