### PR TITLE
remove specific version of net-http-persistent in gemspec

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "uri_template"
   spec.add_dependency "thor"
   spec.add_dependency "rack"
-  spec.add_dependency "net-http-persistent", "< 3.0"
+  spec.add_dependency "net-http-persistent"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Changes proposed in this pull request:

- I would like to remove specific version of net-http-persistent in gemspec if there is no special reason.
