### PR TITLE
Drop mime-types gem dependency

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['~> 2.0']
 
-  spec.add_dependency "mime-types"
   spec.add_dependency "colorize"
   spec.add_dependency "open_uri_redirections"
   spec.add_dependency "activesupport"

--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -7,7 +7,6 @@ require 'typhoeus'
 
 require 'active_support/core_ext/date/conversions'
 require 'active_support/core_ext/time/conversions'
-require 'mime/types'
 require 'open_uri_redirections'
 require 'uri_template'
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Drop `mime-types` gem dependency

Because

- It's introduced at https://github.com/theodi/csvlint.rb/commit/cc41f9a9f0bdc56d722cabe0ed05df320b48ffbc
- But it's no longer used since https://github.com/theodi/csvlint.rb/commit/02ce93d11ca3a42d8d032f358ed8167eeb7dc710
