### PR TITLE
Ruby 2.4 now required, 2.6 not yet supported

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ['~> 2.0']
-
+  spec.required_ruby_version = ['~> 2.4', '< 2.6']
+  
   spec.add_dependency "rainbow"
   spec.add_dependency "open_uri_redirections"
   spec.add_dependency "activesupport"


### PR DESCRIPTION
2.4 is the oldest version of Ruby in support, and there are build failures currently on 2.6, so restrict the support to those versions in between.