### PR TITLE
Fix load_from_json deprecation warnings.

### DIFF
--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -58,7 +58,7 @@ module Csvlint
 
       def get_schema(schema)
         begin
-          schema = Csvlint::Schema.load_from_json(schema, false)
+          schema = Csvlint::Schema.load_from_uri(schema, false)
         rescue Csvlint::Csvw::MetadataError => e
           return_error "invalid metadata: #{e.message}#{" at " + e.path if e.path}"
         rescue OpenURI::HTTPError, Errno::ENOENT

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -252,7 +252,7 @@ module Csvlint
         if rel == "describedby" && param == "type" && ["application/csvm+json", "application/ld+json", "application/json"].include?(param_value)
           begin
             url = URI.join(@source_url, uri)
-            schema = Schema.load_from_json(url)
+            schema = Schema.load_from_uri(url)
             if schema.instance_of? Csvlint::Csvw::TableGroup
               if schema.tables[@source_url]
                 @schema = schema
@@ -462,7 +462,7 @@ module Csvlint
           path = template.expand('url' => @source_url)
           url = URI.join(@source_url, path)
           url = File.new(url.to_s.sub(/^file:/, "")) if url.to_s =~ /^file:/
-          schema = Schema.load_from_json(url)
+          schema = Schema.load_from_uri(url)
           if schema.instance_of? Csvlint::Csvw::TableGroup
             if schema.tables[@source_url]
               @schema = schema

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -174,7 +174,7 @@ describe Csvlint::Schema do
     end
 
     it "should create a schema from a JSON Table URL" do
-      schema = Csvlint::Schema.load_from_json("http://example.com/example.json")
+      schema = Csvlint::Schema.load_from_uri("http://example.com/example.json")
       expect( schema.uri ).to eql("http://example.com/example.json")
       expect( schema.fields.length ).to eql(3)
       expect( schema.fields[0].name ).to eql("ID")
@@ -203,7 +203,7 @@ describe Csvlint::Schema do
     end
 
     it "should create a table group from a CSVW metadata URL" do
-      schema = Csvlint::Schema.load_from_json("http://example.com/metadata.json")
+      schema = Csvlint::Schema.load_from_uri("http://example.com/metadata.json")
       expect( schema.class ).to eq(Csvlint::Csvw::TableGroup)
     end
   end


### PR DESCRIPTION
Use Csvlint::Schema.load_from_uri instead, as directed by the warning.

Cloning the repo and running `rake spec` only to be presented with a screenful of deprecation warnings was, erm, unsettling. This is a tiny change to resolve those warnings, although I haven't actually removed the deprecated method.
