### PR TITLE
Fix csvw tests

### DIFF
--- a/features/support/load_tests.rb
+++ b/features/support/load_tests.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'open-uri'
 require 'uri'
 
-BASE_URI = "http://www.w3.org/2013/csvw/tests/"
+BASE_URI = "https://w3c.github.io/csvw/tests/"
 BASE_PATH = File.join(File.dirname(__FILE__), "..", "fixtures", "csvw")
 FEATURE_BASE_PATH = File.join(File.dirname(__FILE__), "..")
 VALIDATION_FEATURE_FILE_PATH = File.join(FEATURE_BASE_PATH, "csvw_validation_tests.feature")
@@ -31,14 +31,14 @@ end
 
 File.open(SCRIPT_FILE_PATH, 'w') do |file|
 	File.chmod(0755, SCRIPT_FILE_PATH)
-	manifest = JSON.parse( open("http://www.w3.org/2013/csvw/tests/manifest-validation.jsonld").read )
+	manifest = JSON.parse( open("#{BASE_URI}manifest-validation.jsonld").read )
 	manifest["entries"].each do |entry|
 		type = "valid"
-		case entry["type"] 
-		when "csvt:WarningValidationTest" 
-			type = "warnings" 
-		when "csvt:NegativeValidationTest" 
-			type = "errors" 
+		case entry["type"]
+		when "csvt:WarningValidationTest"
+			type = "warnings"
+		when "csvt:NegativeValidationTest"
+			type = "errors"
 		end
 		file.puts "echo \"#{entry["id"].split("#")[-1]}: #{entry["name"].gsub("`", "'")}\""
 		file.puts "echo \"#{type}: #{entry["comment"].gsub("\"", "\\\"").gsub("`", "'")}\""
@@ -54,14 +54,14 @@ File.open(SCRIPT_FILE_PATH, 'w') do |file|
 end unless File.exist? SCRIPT_FILE_PATH
 
 File.open(VALIDATION_FEATURE_FILE_PATH, 'w') do |file|
-	file.puts "# Auto-generated file based on standard validation CSVW tests from http://www.w3.org/2013/csvw/tests/manifest-validation.jsonld"
+	file.puts "# Auto-generated file based on standard validation CSVW tests from #{BASE_URI}manifest-validation.jsonld"
 	file.puts ""
 
-	manifest = JSON.parse( open("http://www.w3.org/2013/csvw/tests/manifest-validation.jsonld").read )
+	manifest = JSON.parse( open("#{BASE_URI}manifest-validation.jsonld").read )
 
 	file.puts "Feature: #{manifest["label"]}"
 	file.puts ""
-	
+
 	manifest["entries"].each do |entry|
 		action_uri, action_file = cache_file(entry["action"])
 		metadata = nil
@@ -85,7 +85,7 @@ File.open(VALIDATION_FEATURE_FILE_PATH, 'w') do |file|
 			end
 			provided_files << action_uri.to_s
 			if entry["name"].include?("/.well-known/csvm")
-				file.puts "\t\tAnd I have a file called \"w3.org/.well-known/csvm\" at the url \"http://www.w3.org/.well-known/csvm\""
+				file.puts "\t\tAnd I have a file called \"w3.org/.well-known/csvm\" at the url \"https://www.w3.org/.well-known/csvm\""
 	  			missing_files << "#{action_uri}.json"
 	  			missing_files << URI.join(action_uri, 'csvm.json').to_s
 			else

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,1 +1,3 @@
 require 'webmock/cucumber'
+
+WebMock.disable_net_connect!(allow: %r{csvw/tests})


### PR DESCRIPTION
This PR fixes the CSV-on-the-web tests by fetching them direct from github. The w3 URLs used before redirect to github, but do not use HTTPS, so cause errors when following the redirects. When that's fixed, we can change back to the canonical w3 URLs.