### PR TITLE
Include active_support/object to ensure this works in ruby 2.6

### DIFF
--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -7,6 +7,7 @@ require 'typhoeus'
 
 require 'active_support/core_ext/date/conversions'
 require 'active_support/core_ext/time/conversions'
+require 'active_support/core_ext/object'
 require 'open_uri_redirections'
 require 'uri_template'
 


### PR DESCRIPTION
This PR fixes #229 

Changes proposed in this pull request:
As is mentioned in the comments of the addressed issue, ruby 2.6 doesn't implement the `present?` method on `Object`. If we include that behavior it should continue to work 😃 