### PR TITLE
optimize validation with regular expression

### DIFF
--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -52,8 +52,7 @@ module Csvlint
       pattern = constraints["pattern"]
       if pattern
         begin
-          Regexp.new(pattern)
-          if !value.nil? && !value.match(constraints["pattern"])
+          if !value.nil? && !value.match(Regexp.new(pattern))
             build_errors(:pattern, :schema, row, column, value,
               {"pattern" => constraints["pattern"]})
           end

--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -10,6 +10,7 @@ module Csvlint
       @uniques = Set.new
       @title = title
       @description = description
+      @regex = nil
       reset
     end
 
@@ -52,7 +53,7 @@ module Csvlint
       pattern = constraints["pattern"]
       if pattern
         begin
-          if !value.nil? && !value.match(Regexp.new(pattern))
+          if !value.nil? && !value.match(@regex ||= Regexp.new(pattern))
             build_errors(:pattern, :schema, row, column, value,
               {"pattern" => constraints["pattern"]})
           end


### PR DESCRIPTION
This PR improves the performance of regular expression-based validation. The changes in this PR reduced the time to validate a 10,000 line CSV file with 25 regular expression validations per line from 10 seconds to 1 second.

The results of the profiler run are as follows.
Before the change, most of the time is spent validating with regular expressions.

[before](https://gist.github.com/youpy/b6f5ead29f2afac24f5985e997642ba0)
[after](https://gist.github.com/youpy/b3316b84aab9399688761c747e6b7fc2)

Changes proposed in this pull request:

- reduce instantiation of extra regular expression objects
