### PR TITLE
Update syntax from StandardRb specification and specify ActiveSupport version

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -41,3 +41,7 @@ ignore:
   - Lint/NonLocalExitFromIterator
 - spec/validator_spec.rb:
   - Lint/UselessAssignment
+- lib/csvlint/schema.rb:
+  - Lint/UselessRescue
+- lib/csvlint/validate.rb:
+  -  Lint/UselessRescue

--- a/lib/csvlint/csvw/column.rb
+++ b/lib/csvlint/csvw/column.rb
@@ -126,14 +126,14 @@ module Csvlint
             format = Csvlint::Csvw::DateFormat.new(nil, type) if format.nil?
             v = format.parse(value)
             return nil, warning if v.nil?
-            return v, nil
+            [v, nil]
           }
         end
 
         def create_regexp_based_parser(regexp, warning)
           lambda { |value, format|
             return nil, warning unless value&.match?(regexp)
-            return value, nil
+            [value, nil]
           }
         end
 
@@ -256,14 +256,14 @@ module Csvlint
         "http://www.w3.org/2001/XMLSchema#time" => NO_ADDITIONAL_VALIDATION
       }
 
-      TRIM_VALUE = lambda { |value, format| return value.strip, nil }
-      ALL_VALUES_VALID = lambda { |value, format| return value, nil }
+      TRIM_VALUE = lambda { |value, format| [value.strip, nil] }
+      ALL_VALUES_VALID = lambda { |value, format| [value, nil] }
 
       NUMERIC_PARSER = lambda { |value, format, integer = false|
         format = Csvlint::Csvw::NumberFormat.new(nil, nil, ".", integer) if format.nil?
         v = format.parse(value)
         return nil, :invalid_number if v.nil?
-        return v, nil
+        [v, nil]
       }
 
       DATATYPE_PARSER = {
@@ -281,7 +281,7 @@ module Csvlint
             return true, nil if value == format[0]
             return false, nil if value == format[1]
           end
-          return value, :invalid_boolean
+          [value, :invalid_boolean]
         },
         "http://www.w3.org/2001/XMLSchema#date" =>
           create_date_parser("http://www.w3.org/2001/XMLSchema#date", :invalid_date),
@@ -291,85 +291,85 @@ module Csvlint
           create_date_parser("http://www.w3.org/2001/XMLSchema#dateTimeStamp", :invalid_date_time_stamp),
         "http://www.w3.org/2001/XMLSchema#decimal" => lambda { |value, format|
           return nil, :invalid_decimal if /(E|e|^(NaN|INF|-INF)$)/.match?(value)
-          return NUMERIC_PARSER.call(value, format)
+          NUMERIC_PARSER.call(value, format)
         },
         "http://www.w3.org/2001/XMLSchema#integer" => lambda { |value, format|
           v, w = NUMERIC_PARSER.call(value, format, true)
           return v, :invalid_integer unless w.nil?
           return nil, :invalid_integer unless v.is_a? Integer
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#long" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_long unless w.nil?
           return nil, :invalid_long unless v <= 9223372036854775807 && v >= -9223372036854775808
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#int" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_int unless w.nil?
           return nil, :invalid_int unless v <= 2147483647 && v >= -2147483648
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#short" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_short unless w.nil?
           return nil, :invalid_short unless v <= 32767 && v >= -32768
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#byte" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_byte unless w.nil?
           return nil, :invalid_byte unless v <= 127 && v >= -128
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#nonNegativeInteger" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_nonNegativeInteger unless w.nil?
           return nil, :invalid_nonNegativeInteger unless v >= 0
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#positiveInteger" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_positiveInteger unless w.nil?
           return nil, :invalid_positiveInteger unless v > 0
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#unsignedLong" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#nonNegativeInteger"].call(value, format)
           return v, :invalid_unsignedLong unless w.nil?
           return nil, :invalid_unsignedLong unless v <= 18446744073709551615
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#unsignedInt" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#nonNegativeInteger"].call(value, format)
           return v, :invalid_unsignedInt unless w.nil?
           return nil, :invalid_unsignedInt unless v <= 4294967295
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#unsignedShort" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#nonNegativeInteger"].call(value, format)
           return v, :invalid_unsignedShort unless w.nil?
           return nil, :invalid_unsignedShort unless v <= 65535
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#unsignedByte" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#nonNegativeInteger"].call(value, format)
           return v, :invalid_unsignedByte unless w.nil?
           return nil, :invalid_unsignedByte unless v <= 255
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#nonPositiveInteger" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_nonPositiveInteger unless w.nil?
           return nil, :invalid_nonPositiveInteger unless v <= 0
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#negativeInteger" => lambda { |value, format|
           v, w = DATATYPE_PARSER["http://www.w3.org/2001/XMLSchema#integer"].call(value, format)
           return v, :invalid_negativeInteger unless w.nil?
           return nil, :invalid_negativeInteger unless v < 0
-          return v, w
+          [v, w]
         },
         "http://www.w3.org/2001/XMLSchema#double" => NUMERIC_PARSER,
         # regular expressions here taken from XML Schema datatypes spec

--- a/lib/csvlint/csvw/property_checker.rb
+++ b/lib/csvlint/csvw/property_checker.rb
@@ -60,7 +60,7 @@ module Csvlint
                 raise Csvlint::Csvw::MetadataError.new, "common property with @value has properties other than @language or @type" unless value.except("@type").except("@language").except("@value").empty?
               when "@language"
                 raise Csvlint::Csvw::MetadataError.new, "common property with @language lacks a @value" unless value["@value"]
-                raise Csvlint::Csvw::MetadataError.new, "common property has invalid @language (#{v})" unless ((v.is_a? String) && (v =~ BCP47_LANGUAGE_REGEXP)) || v.nil?
+                raise Csvlint::Csvw::MetadataError.new, "common property has invalid @language (#{v})" if !((v.is_a? String) && (v =~ BCP47_LANGUAGE_REGEXP)) || !v.nil?
               else
                 if p[0] == "@"
                   raise Csvlint::Csvw::MetadataError.new, "common property has property other than @id, @type, @value or @language beginning with @ (#{p})"
@@ -423,7 +423,7 @@ module Csvlint
                   elsif p == "titles"
                   else
                     v, warning, type = check_property(p, v, base_url, lang)
-                    unless type == :transformation && (warning.nil? || warning.empty?)
+                    if type != :transformation && !(warning.nil? || warning.empty?)
                       value.delete(p)
                       warnings << :invalid_property unless type == :transformation
                       warnings += Array(warning)

--- a/lib/csvlint/csvw/property_checker.rb
+++ b/lib/csvlint/csvw/property_checker.rb
@@ -99,7 +99,7 @@ module Csvlint
               v = format.parse(value[property])
               if v.nil?
                 value.delete(property)
-                return [":invalid_#{property}".to_sym]
+                return [:":invalid_#{property}"]
               else
                 value[property] = v
                 return []
@@ -116,35 +116,35 @@ module Csvlint
         def array_property(type)
           lambda { |value, base_url, lang|
             return value, nil, type if value.instance_of? Array
-            return false, :invalid_value, type
+            [false, :invalid_value, type]
           }
         end
 
         def boolean_property(type)
           lambda { |value, base_url, lang|
             return value, nil, type if value == true || value == false
-            return false, :invalid_value, type
+            [false, :invalid_value, type]
           }
         end
 
         def string_property(type)
           lambda { |value, base_url, lang|
             return value, nil, type if value.instance_of? String
-            return "", :invalid_value, type
+            ["", :invalid_value, type]
           }
         end
 
         def uri_template_property(type)
           lambda { |value, base_url, lang|
             return URITemplate.new(value), nil, type if value.instance_of? String
-            return URITemplate.new(""), :invalid_value, type
+            [URITemplate.new(""), :invalid_value, type]
           }
         end
 
         def numeric_property(type)
           lambda { |value, base_url, lang|
             return value, nil, type if value.is_a?(Integer) && value >= 0
-            return nil, :invalid_value, type
+            [nil, :invalid_value, type]
           }
         end
 
@@ -152,14 +152,14 @@ module Csvlint
           lambda { |value, base_url, lang|
             raise Csvlint::Csvw::MetadataError.new, "URL #{value} starts with _:" if /^_:/.match?(value.to_s)
             return (base_url.nil? ? URI(value) : URI.join(base_url, value)), nil, type if value.instance_of? String
-            return base_url, :invalid_value, type
+            [base_url, :invalid_value, type]
           }
         end
 
         def language_property(type)
           lambda { |value, base_url, lang|
             return value, nil, type if BCP47_REGEXP.match?(value)
-            return nil, :invalid_value, type
+            [nil, :invalid_value, type]
           }
         end
 
@@ -167,7 +167,7 @@ module Csvlint
           lambda { |value, base_url, lang|
             warnings = []
             if value.instance_of? String
-              return {lang => [value]}, nil, type
+              [{lang => [value]}, nil, type]
             elsif value.instance_of? Array
               valid_titles = []
               value.each do |title|
@@ -177,7 +177,7 @@ module Csvlint
                   warnings << :invalid_value
                 end
               end
-              return {lang => valid_titles}, warnings, type
+              [{lang => valid_titles}, warnings, type]
             elsif value.instance_of? Hash
               value = value.clone
               value.each do |l, v|
@@ -197,16 +197,16 @@ module Csvlint
                 end
               end
               warnings << :invalid_value if value.empty?
-              return value, warnings, type
+              [value, warnings, type]
             else
-              return {}, :invalid_value, type
+              [{}, :invalid_value, type]
             end
           }
         end
 
         def column_reference_property(type)
           lambda { |value, base_url, lang|
-            return Array(value), nil, type
+            [Array(value), nil, type]
           }
         end
       end
@@ -226,7 +226,7 @@ module Csvlint
             values << v
             warnings += w
           end
-          return values, warnings, :common
+          [values, warnings, :common]
         },
         "suppressOutput" => boolean_property(:common),
         "dialect" => lambda { |value, base_url, lang|
@@ -249,16 +249,16 @@ module Csvlint
                 end
               end
             end
-            return value, warnings, :common
+            [value, warnings, :common]
           else
-            return {}, :invalid_value, :common
+            [{}, :invalid_value, :common]
           end
         },
         # inherited properties
         "null" => lambda { |value, base_url, lang|
           case value
           when String
-            return [value], nil, :inherited
+            [[value], nil, :inherited]
           when Array
             values = []
             warnings = []
@@ -269,15 +269,15 @@ module Csvlint
                 warnings << :invalid_value
               end
             end
-            return values, warnings, :inherited
+            [values, warnings, :inherited]
           else
-            return [""], :invalid_value, :inherited
+            [[""], :invalid_value, :inherited]
           end
         },
         "default" => string_property(:inherited),
         "separator" => lambda { |value, base_url, lang|
           return value, nil, :inherited if value.instance_of?(String) || value.nil?
-          return nil, :invalid_value, :inherited
+          [nil, :invalid_value, :inherited]
         },
         "lang" => language_property(:inherited),
         "datatype" => lambda { |value, base_url, lang|
@@ -387,7 +387,7 @@ module Csvlint
               end
             end
           end
-          return value, warnings, :inherited
+          [value, warnings, :inherited]
         },
         "required" => boolean_property(:inherited),
         "ordered" => boolean_property(:inherited),
@@ -397,14 +397,14 @@ module Csvlint
         "textDirection" => lambda { |value, base_url, lang|
           value = value.to_sym
           return value, nil, :inherited if [:ltr, :rtl, :auto, :inherit].include? value
-          return :inherit, :invalid_value, :inherited
+          [:inherit, :invalid_value, :inherited]
         },
         # column level properties
         "virtual" => boolean_property(:column),
         "titles" => natural_language_property(:column),
         "name" => lambda { |value, base_url, lang|
           return value, nil, :column if value.instance_of?(String) && value =~ NAME_REGEXP
-          return nil, :invalid_value, :column
+          [nil, :invalid_value, :column]
         },
         # table level properties
         "transformations" => lambda { |value, base_url, lang|
@@ -438,12 +438,12 @@ module Csvlint
           else
             warnings << :invalid_value
           end
-          return transformations, warnings, :table
+          [transformations, warnings, :table]
         },
         "tableDirection" => lambda { |value, base_url, lang|
           value = value.to_sym
           return value, nil, :table if [:ltr, :rtl, :auto].include? value
-          return :auto, :invalid_value, :table
+          [:auto, :invalid_value, :table]
         },
         "tableSchema" => lambda { |value, base_url, lang|
           schema_base_url = base_url
@@ -483,7 +483,7 @@ module Csvlint
               end
             end
           end
-          return schema, warnings, :table
+          [schema, warnings, :table]
         },
         "url" => link_property(:table),
         # dialect properties
@@ -492,7 +492,7 @@ module Csvlint
         "doubleQuote" => boolean_property(:dialect),
         "encoding" => lambda { |value, base_url, lang|
           return value, nil, :dialect if VALID_ENCODINGS.include? value
-          return nil, :invalid_value, :dialect
+          [nil, :invalid_value, :dialect]
         },
         "header" => boolean_property(:dialect),
         "headerRowCount" => numeric_property(:dialect),
@@ -508,10 +508,10 @@ module Csvlint
           value = :start if value == "start"
           value = :end if value == "end"
           return value, nil, :dialect if [:true, :false, :start, :end].include? value
-          return true, :invalid_value, :dialect
+          [true, :invalid_value, :dialect]
         },
         # schema properties
-        "columns" => lambda { |value, base_url, lang| return value, nil, :schema },
+        "columns" => lambda { |value, base_url, lang| [value, nil, :schema] },
         "primaryKey" => column_reference_property(:schema),
         "foreignKeys" => lambda { |value, base_url, lang|
           foreign_keys = []
@@ -540,13 +540,13 @@ module Csvlint
           else
             warnings << :invalid_value
           end
-          return foreign_keys, warnings, :schema
+          [foreign_keys, warnings, :schema]
         },
         "rowTitles" => column_reference_property(:schema),
         # transformation properties
-        "targetFormat" => lambda { |value, base_url, lang| return value, nil, :transformation },
-        "scriptFormat" => lambda { |value, base_url, lang| return value, nil, :transformation },
-        "source" => lambda { |value, base_url, lang| return value, nil, :transformation },
+        "targetFormat" => lambda { |value, base_url, lang| [value, nil, :transformation] },
+        "scriptFormat" => lambda { |value, base_url, lang| [value, nil, :transformation] },
+        "source" => lambda { |value, base_url, lang| [value, nil, :transformation] },
         # foreignKey properties
         "columnReference" => column_reference_property(:foreign_key),
         "reference" => lambda { |value, base_url, lang|
@@ -572,15 +572,15 @@ module Csvlint
             raise Csvlint::Csvw::MetadataError.new("foreignKey.reference.columnReference"), "foreignKey reference columnReference is missing" unless value["columnReference"]
             raise Csvlint::Csvw::MetadataError.new("foreignKey.reference"), "foreignKey reference does not have either resource or schemaReference" unless value["resource"] || value["schemaReference"]
             raise Csvlint::Csvw::MetadataError.new("foreignKey.reference"), "foreignKey reference has both resource and schemaReference" if value["resource"] && value["schemaReference"]
-            return value, warnings, :foreign_key
+            [value, warnings, :foreign_key]
           else
             raise Csvlint::Csvw::MetadataError.new("foreignKey.reference"), "foreignKey reference is not an object"
           end
         },
         # foreignKey reference properties
-        "resource" => lambda { |value, base_url, lang| return value, nil, :foreign_key_reference },
+        "resource" => lambda { |value, base_url, lang| [value, nil, :foreign_key_reference] },
         "schemaReference" => lambda { |value, base_url, lang|
-          return URI.join(base_url, value).to_s, nil, :foreign_key_reference
+          [URI.join(base_url, value).to_s, nil, :foreign_key_reference]
         }
       }
 

--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -16,7 +16,7 @@ module Csvlint
 
     def validate_column(value, row = nil, column = nil, all_errors = [])
       reset
-      unless all_errors.any? { |error| ((error.type == :invalid_regex) && (error.column == column)) }
+      unless all_errors.any? { |error| (error.type == :invalid_regex) && (error.column == column) }
         validate_regex(value, row, column, all_errors)
       end
       validate_length(value, row, column)

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -36,8 +36,6 @@ module Csvlint
 
       def load_from_uri(uri, output_errors = true)
         load_from_string(uri, URI.open(uri).read, output_errors)
-      rescue OpenURI::HTTPError, Errno::ENOENT => e
-        raise e
       end
 
       def load_from_string(uri, string, output_errors = true)

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -36,6 +36,8 @@ module Csvlint
 
       def load_from_uri(uri, output_errors = true)
         load_from_string(uri, URI.open(uri).read, output_errors)
+      rescue OpenURI::HTTPError, Errno::ENOENT => e
+        raise e
       end
 
       def load_from_string(uri, string, output_errors = true)

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -495,10 +495,6 @@ module Csvlint
             build_warnings(:schema_mismatch, :context, nil, nil, @source_url, schema)
           end
         end
-      rescue Errno::ENOENT
-      rescue OpenURI::HTTPError, URI::BadURIError, ArgumentError
-      rescue => e
-        raise e
       end
       build_warnings(:schema_mismatch, :context, nil, nil, @source_url, schema) if warn_if_unsuccessful
       @schema = nil

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -495,6 +495,10 @@ module Csvlint
             build_warnings(:schema_mismatch, :context, nil, nil, @source_url, schema)
           end
         end
+      rescue Errno::ENOENT
+      rescue OpenURI::HTTPError, URI::BadURIError, ArgumentError
+      rescue => e
+        raise e
       end
       build_warnings(:schema_mismatch, :context, nil, nil, @source_url, schema) if warn_if_unsuccessful
       @schema = nil

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -590,14 +590,14 @@ module Csvlint
       numeric: /\A[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\z/,
       uri: /\Ahttps?:/,
       date_db: /\A\d{4,}-\d\d-\d\d\z/, # "12345-01-01"
-      date_long: /\A(?:#{Date::MONTHNAMES.join('|')}) [ \d]\d, \d{4,}\z/, # "January  1, 12345"
-      date_rfc822: /\A[ \d]\d (?:#{Date::ABBR_MONTHNAMES.join('|')}) \d{4,}\z/, # " 1 Jan 12345"
-      date_short: /\A[ \d]\d (?:#{Date::ABBR_MONTHNAMES.join('|')})\z/, # "1 Jan"
+      date_long: /\A(?:#{Date::MONTHNAMES.join("|")}) [ \d]\d, \d{4,}\z/, # "January  1, 12345"
+      date_rfc822: /\A[ \d]\d (?:#{Date::ABBR_MONTHNAMES.join("|")}) \d{4,}\z/, # " 1 Jan 12345"
+      date_short: /\A[ \d]\d (?:#{Date::ABBR_MONTHNAMES.join("|")})\z/, # "1 Jan"
       dateTime_db: /\A\d{4,}-\d\d-\d\d \d\d:\d\d:\d\d\z/, # "12345-01-01 00:00:00"
       dateTime_hms: /\A\d\d:\d\d:\d\d\z/, # "00:00:00"
       dateTime_iso8601: /\A\d{4,}-\d\d-\d\dT\d\d:\d\d:\d\dZ\z/, # "12345-01-01T00:00:00Z"
-      dateTime_long: /\A(?:#{Date::MONTHNAMES.join('|')}) \d\d, \d{4,} \d\d:\d\d\z/, # "January 01, 12345 00:00"
-      dateTime_short: /\A\d\d (?:#{Date::ABBR_MONTHNAMES.join('|')}) \d\d:\d\d\z/, # "01 Jan 00:00"
+      dateTime_long: /\A(?:#{Date::MONTHNAMES.join("|")}) \d\d, \d{4,} \d\d:\d\d\z/, # "January 01, 12345 00:00"
+      dateTime_short: /\A\d\d (?:#{Date::ABBR_MONTHNAMES.join("|")}) \d\d:\d\d\z/, # "01 Jan 00:00"
       dateTime_time: /\A\d\d:\d\d\z/ # "00:00"
     }.freeze
 


### PR DESCRIPTION
This PR fixes:
- #284 
- #280

Changes proposed in this pull request:

- Update syntax in accordance with StandardRb
  - [Remove redundant returns](https://github.com/Data-Liberation-Front/csvlint.rb/commit/a5f2ec5c58abccd027bb9996015f7fb4d679b8fb)
  - [Remove unnecessary parentheses](https://github.com/Data-Liberation-Front/csvlint.rb/commit/c023be9a5f11ec167db8a82de043dbc970dcdb22)
  - [Use double quotes](https://github.com/Data-Liberation-Front/csvlint.rb/commit/f4bf8a4633c5506262e12c0fe210d87e7bc484f6)
  - [Invert condition to not mix logical operator in an unless](https://github.com/Data-Liberation-Front/csvlint.rb/commit/cb0451b4ff45b48ee22e25954b6f43bd1930124f)
  - [Ignore UselessRescue because used for test purposes](https://github.com/Data-Liberation-Front/csvlint.rb/pull/285/commits/f5c5990e41acc89ae928147864179fa4ef2a0adc)
- Lock ActiveSupport to pass the tests (code from https://github.com/Data-Liberation-Front/csvlint.rb/pull/279)

Fix #284
Fix #280
